### PR TITLE
Made double parsing culture invariant for opencover format

### DIFF
--- a/src/Parsing/Processors/OpenCoverProcessor.cs
+++ b/src/Parsing/Processors/OpenCoverProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 using Codacy.CSharpCoverage.Models.OpenCover;
@@ -47,7 +48,7 @@ namespace Codacy.CSharpCoverage.Parsing.Processors
 
                     var coverageInfo = new ClassCoverage
                     {
-                        SequenceCoverage = Convert.ToDouble(summaryElem.Attribute("sequenceCoverage").Value)
+                        SequenceCoverage = Convert.ToDouble(summaryElem.Attribute("sequenceCoverage").Value , CultureInfo.InvariantCulture)
                     };
 
                     int? fileId = null;


### PR DESCRIPTION
### The problem
On machines with non-US culture the app fails with an exception:
```
Unhandled Exception: System.FormatException: Input string was not in a correct format.
   at System.Number.ParseDouble(ReadOnlySpan`1 value, NumberStyles options, NumberFormatInfo numfmt)
   at Codacy.CSharpCoverage.Parsing.Processors.OpenCoverProcessor.Parse(String file)
   at Codacy.CSharpCoverage.Program.<>c.<Main>b__0_0(Options opt)
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at Codacy.CSharpCoverage.Program.Main(String[] args)
```

### The solution
Make double parsing culture invariant