### PR TITLE
made publish use trimming and warp pack

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,13 +6,14 @@ mkdir -p artifacts/
 
 pushd src
 	if [[ $1 == "netcoreapp3.0" ]]; then
-		dotnet publish -c Release -f $1 -r $2 /p:PublishSingleFile=true /p:UsePreviewVersion=true
+		dotnet tool install --global dotnet-warp || true
+		dotnet warp -r $2 -p Configuration=Release -p PublishTrimmed=true -p UsePreviewVersion=true
 		if [[ $2 == win-* ]]; then
 			BIN_EXT=".exe"
 		else
 			BIN_EXT=""
 		fi
-		mv -f "bin/Release/$1/$2/publish/Codacy.CSharpCoverage$BIN_EXT" "../artifacts/Codacy.CSharpCoverage_$2$BIN_EXT"
+		mv -f "Codacy.CSharpCoverage$BIN_EXT" "../artifacts/Codacy.CSharpCoverage_$2$BIN_EXT"
 	else
 		dotnet publish -c Release -f $1 -r $2
 		pushd bin/Release/$1/$2/publish

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,8 +6,9 @@ mkdir -p artifacts/
 
 pushd src
 	if [[ $1 == "netcoreapp3.0" ]]; then
-		dotnet tool install --global dotnet-warp || true
-		dotnet warp -r $2 -p Configuration=Release -p PublishTrimmed=true -p UsePreviewVersion=true
+		dotnet new tool-manifest --force
+		dotnet tool install --local dotnet-warp
+		dotnet warp -r "$2" -p "Configuration=Release" -p "PublishTrimmed=true" -p "UsePreviewVersion=true"
 		if [[ $2 == win-* ]]; then
 			BIN_EXT=".exe"
 		else


### PR DESCRIPTION
These changes allow the output single file to be much smaller. It is very important for scenarios when you build your app in one-time-use docker container. Downloading 70 megs takes a lot of time!
![image](https://user-images.githubusercontent.com/4095184/68855668-08015480-06df-11ea-893c-168c87d83c71.png)



