### PR TITLE
Added exit code 1 when cmd line not parsed correctly

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,8 +10,10 @@ namespace Codacy.CSharpCoverage
 {
     internal class Program
     {
-        private static void Main(string[] args)
+        private static int Main(string[] args)
         {
+            int exitcode = 0;
+
             // parse the option arguments
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed(opt =>
@@ -54,7 +56,10 @@ namespace Codacy.CSharpCoverage
 
                         SendReport(report, opt.CommitUUID, opt.Token, opt.Partial);
                     }
-                });
+                })
+                .WithNotParsed(errs => exitcode = 1);
+
+            return exitcode;
         }
 
         /// <summary>


### PR DESCRIPTION
### The problem 
My CI build is executed like this
```bash
./codacy -c $HASH -t $TOKEN -r $coverage_file -e opencover
```
and I forgot to set the $TOKEN, the result however is successful
```bash
Codacy.CSharpCoverage 1.0.0
Copyright (C) 2019 Codacy.CSharpCoverage

ERROR(S):
  Option 't, token' has no value.
  Required option 't, token' is missing.

> echo $?
0
```

### The solution
Make the app return status code 1 when there were command line parsing errors